### PR TITLE
chore: change levels and offset params to select

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -63,6 +63,7 @@ div.parameter {
 
 div.parameter select, div.parameter input {
 	display: block;
+	min-width: 50px;
 	margin: 3px auto;
 	text-align: center;
 	text-align-last: center;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
           <option value="Phrygian">Phrygian</option>
           <option value="Lydian">Lydian</option>
           <option value="Mixolydian">Mixolydian</option>
-          <option value="Aeolian">Aeolian</option>          
+          <option value="Aeolian">Aeolian</option>
           <option value="Locrian">Locrian</option>
           <option disabled></option>
           <option value="Pentatonic">Pentatonic</option>
@@ -84,12 +84,31 @@
       </div>
 
       <div class="parameter">
-        <input type="text" name="levels" id="levels" size="3" value="3" />
+        <select id="levels">
+          <option value="0">0</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option selected value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+        </select>
         <label for="levels">Levels</label>
       </div>
 
+
       <div class="parameter">
-        <input type="text" name="offset" id="offset" size="3" value="0" />
+        <select id="offset">
+          <option value="0">0</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+        </select>
         <label for="offset">Offset</label>
       </div>
 
@@ -105,12 +124,12 @@
       </div>
 
       <div class="parameter">
-		  <div id='copy'>
+        <div id="copy">
           <img
             src="assets/content_copy_white_24dp.svg"
             alt="Copy link to clipboard"
           />
-		  </div>
+        </div>
         <label for="copy">Copy link</label>
       </div>
     </div>

--- a/js/index.js
+++ b/js/index.js
@@ -57,7 +57,6 @@ KochSynth.DELAY_FEEDBACK = 0.25;
 KochSynth.REVERB_WET = 0.35;
 KochSynth.REVERB_DECAY = 4;
 
-
 KochSynth.prototype.setTempo = function (tempo) {
   this.tempo = tempo;
   Tone.Transport.bpm.value = this.tempo;


### PR DESCRIPTION
This PR updates the app UI to have the *levels* and *offset* parameters picked from a `select` rather than an `input` text box.